### PR TITLE
add token transfers v2 job to batch

### DIFF
--- a/dags/ethereumetl_airflow/build_load_dag_redshift.py
+++ b/dags/ethereumetl_airflow/build_load_dag_redshift.py
@@ -74,6 +74,7 @@ def build_load_dag_redshift(
             'logs': 'block_number',
             'receipts': 'block_number',
             'token_transfers': 'block_number',
+            'token_transfers_v2': 'block_number',
             'tokens': 'address',
             'traces': 'block_number',
             'transactions': 'block_number'
@@ -141,6 +142,7 @@ def build_load_dag_redshift(
     load_contracts_task = add_load_tasks('contracts', 'json')
     load_tokens_task = add_load_tasks('tokens', 'csv')
     load_token_transfers_task = add_load_tasks('token_transfers', 'csv')
+    load_token_transfers_v2_task = add_load_tasks('token_transfers_v2', 'csv')
     load_traces_task = add_load_tasks('traces', 'csv')
 
     return dag

--- a/dags/resources/stages/enrich/sqls/merge/merge_token_transfers_v2.sql
+++ b/dags/resources/stages/enrich/sqls/merge/merge_token_transfers_v2.sql
@@ -1,0 +1,31 @@
+merge `{{params.destination_dataset_project_id}}.{{params.destination_dataset_name}}.token_transfers_v2` dest
+using {{params.dataset_name_temp}}.{{params.source_table}} source
+on false
+when not matched and date(block_timestamp) = '{{ds}}' then
+insert (
+    contract_address,
+    from_address,
+    to_address,
+    amount,
+    token_type,
+    token_ids,
+    transaction_hash,
+    log_index,
+    block_timestamp,
+    block_number,
+    block_hash
+) values (
+    contract_address,
+    from_address,
+    to_address,
+    amount,
+    token_type,
+    token_ids,
+    transaction_hash,
+    log_index,
+    block_timestamp,
+    block_number,
+    block_hash
+)
+when not matched by source and date(block_timestamp) = '{{ds}}' then
+delete

--- a/dags/resources/stages/enrich/sqls/token_transfers_v2.sql
+++ b/dags/resources/stages/enrich/sqls/token_transfers_v2.sql
@@ -1,0 +1,18 @@
+SELECT
+    token_transfers_v2.contract_address,
+    token_transfers_v2.from_address,
+    token_transfers_v2.to_address,
+    token_transfers_v2.amount,
+    token_transfers_v2.token_type,
+    token_transfers_v2.token_ids,
+    token_transfers_v2.transaction_hash,
+    token_transfers_v2.log_index,
+    TIMESTAMP_SECONDS(blocks.timestamp) AS block_timestamp,
+    blocks.number AS block_number,
+    blocks.hash AS block_hash
+FROM {{params.dataset_name_raw}}.blocks AS blocks
+    JOIN {{params.dataset_name_raw}}.token_transfers_v2 AS token_transfers_v2 ON blocks.number = token_transfers_v2.block_number
+where true
+    {% if not params.load_all_partitions %}
+    and date(timestamp_seconds(blocks.timestamp)) = '{{ds}}'
+    {% endif %}

--- a/dags/resources/stages/raw/schemas_redshift/schema.sql
+++ b/dags/resources/stages/raw/schemas_redshift/schema.sql
@@ -97,6 +97,25 @@ SORTKEY (log_index);
 
 --
 
+DROP TABLE IF EXISTS ethereum.token_transfers_v2;
+
+CREATE TABLE ethereum.token_transfers_v2 (
+  contract_address VARCHAR(65535) NOT NULL, -- Contract address
+  from_address     VARCHAR(65535) NOT NULL, -- Address of the sender
+  to_address       VARCHAR(65535) NOT NULL, -- Address of the receiver
+  amount           VARCHAR(65535) NOT NULL, -- Amount of tokens transferred (ERC20) / id of the token transferred (ERC721). Cast to NUMERIC or FLOAT8
+  token_type       VARCHAR(65535) NOT NULL, -- ERC20/ ERC1155/ ERC721
+  token_ids        VARCHAR(65535) NOT NULL, -- id of the token transferred (ERC721)
+  transaction_hash VARCHAR(65535) NOT NULL, -- Transaction hash
+  log_index        BIGINT         NOT NULL, -- Log index in the transaction receipt
+  block_number     BIGINT         NOT NULL, -- The block number
+  PRIMARY KEY (transaction_hash, token_ids)
+)
+DISTKEY (block_number)
+SORTKEY (log_index);
+
+--
+
 DROP TABLE IF EXISTS ethereum.tokens;
 
 CREATE TABLE ethereum.tokens (

--- a/dags/resources/stages/verify/sqls/token_transfers_v2_have_latest.sql
+++ b/dags/resources/stages/verify/sqls/token_transfers_v2_have_latest.sql
@@ -1,0 +1,6 @@
+select if(
+(
+select count(*) from `{{params.destination_dataset_project_id}}.{{params.dataset_name}}.token_transfers_v2`
+where date(block_timestamp) = '{{ds}}'
+) > 0, 1,
+cast((select 'There are no token transfers v2 on {{ds}}') as int64))


### PR DESCRIPTION
## What is the change?
token_transfers_v2 is supported only for kafka export in chain-etl right now. This PR adds the support for adding this in the batch job

## Why do we need it?
Build token_balances batch endpoint based on this output for BI 

## todo
- schema changes in redshift for creating new table and setting primary keys 

## Test plan
Will test on local airflow runner + a test run on airflow prod cluster