### PR TITLE
add tasks to enrich domains

### DIFF
--- a/dags/cli.py
+++ b/dags/cli.py
@@ -1,0 +1,33 @@
+from airflow import DAG
+
+from airflow.operators.bash_operator import BashOperator
+
+from datetime import timedelta,time,datetime
+import os
+
+DAG_ID = os.path.basename(__file__).replace(".py", "")
+
+default_args = {
+            "owner": "airflow",
+            "start_date": datetime(2020, 9, 9),
+            "depends_on_past": False,
+            "email_on_failure": False,
+            "email_on_retry": False,
+            "email": "infrastructure@bitski.com",
+            "retries": 1,
+            "retry_delay": timedelta(minutes=5)
+        }
+
+from time import sleep
+from datetime import datetime
+from random import random
+
+#this is useful because the webserver can't install the requirements.txt dependencies so commands don't work directly through cli
+#the workaround is to setup a dag which can make the cli calls so the calls are executed on the worker instead of webserver
+
+with DAG(dag_id=DAG_ID, schedule_interval=None, default_args=default_args, catchup=False) as dag:
+    cli_command = BashOperator(
+        task_id="cli_command",
+        bash_command="airflow {{ dag_run.conf['command'] }}"
+    )
+    cli_command

--- a/dags/ethereum_partition_dag.py
+++ b/dags/ethereum_partition_dag.py
@@ -16,7 +16,7 @@ DAG = build_partition_dag(
     partitioned_dataset_name = 'crypto_ethereum_partitioned',
     public_project_id = 'bigquery-public-data',
     public_dataset_name = 'crypto_ethereum',
-    load_dag_id='ethereum_load_dag',
+    load_dag_id='ethereum_load_dag_redshift',
     notification_emails=Variable.get('notification_emails', None),
     schedule_interval='30 13 * * *',
 )

--- a/dags/ethereum_verify_streaming_dag.py
+++ b/dags/ethereum_verify_streaming_dag.py
@@ -10,10 +10,10 @@ logging.getLogger().setLevel(logging.DEBUG)
 
 # When searching for DAGs, Airflow will only consider files where the string "airflow" and "DAG" both appear in the
 # contents of the .py file.
-DAG = build_verify_streaming_dag(
-    dag_id='ethereum_verify_streaming_dag',
-    **read_verify_streaming_dag_vars(
-        var_prefix='ethereum_',
-        max_lag_in_minutes=15,
-    )
-)
+# DAG = build_verify_streaming_dag(
+#     dag_id='ethereum_verify_streaming_dag',
+#     **read_verify_streaming_dag_vars(
+#         var_prefix='ethereum_',
+#         max_lag_in_minutes=15,
+#     )
+# )

--- a/dags/ethereumetl_airflow/build_partition_dag.py
+++ b/dags/ethereumetl_airflow/build_partition_dag.py
@@ -26,7 +26,7 @@ def build_partition_dag(
 
     default_dag_args = {
         'depends_on_past': False,
-        'start_date': datetime.strptime('2015-07-30', '%Y-%m-%d'),
+        'start_date': datetime.strptime('2020-12-31', '%Y-%m-%d'),
         'email_on_failure': True,
         'email_on_retry': False,
         'retries': 5,

--- a/dags/requirements.txt
+++ b/dags/requirements.txt
@@ -1,4 +1,5 @@
-ethereum-etl-bitski-patched==2.0.2
+-c https://raw.githubusercontent.com/apache/airflow/constraints-1.10.12/constraints-3.8.txt
+ethereum-etl-bitski-patched==2.1.2
 apache-airflow==1.10.12
 google-cloud-storage==1.30.0
 httplib2==0.18.1
@@ -7,4 +8,3 @@ google-cloud-bigquery==1.26.1
 google-api-python-client==1.10.0
 pandas-gbq==0.13.2
 pandas==1.1.0
-pytest==5.4.1

--- a/dags/resources/stages/enrich/schemas_redshift/schema.sql
+++ b/dags/resources/stages/enrich/schemas_redshift/schema.sql
@@ -1,0 +1,106 @@
+CREATE SCHEMA IF NOT EXISTS ethereum;
+
+DROP TABLE IF EXISTS ethereum.blocks_enrich;
+
+CREATE TABLE ethereum.blocks_enrich (
+  chain_id          BIGINT         DEFAULT 1 NOT NULL,     -- Chain ID of network
+  timestamp         TIMESTAMP      NOT NULL,     -- The unix timestamp for when the block was collated
+  number            BIGINT         NOT NULL,     -- The block number
+  hash              VARCHAR(65535) NOT NULL,     -- Hash of the block
+  parent_hash       VARCHAR(65535) NOT NULL,     -- Hash of the parent block
+  nonce             VARCHAR(65535) NOT NULL,     -- Hash of the generated proof-of-work
+  sha3_uncles       VARCHAR(65535) NOT NULL,     -- SHA3 of the uncles data in the block
+  logs_bloom        VARCHAR(65535) NOT NULL,     -- The bloom filter for the logs of the block
+  transactions_root VARCHAR(65535) NOT NULL,     -- The root of the transaction trie of the block
+  state_root        VARCHAR(65535) NOT NULL,     -- The root of the final state trie of the block
+  receipts_root     VARCHAR(65535) NOT NULL,     -- The root of the receipts trie of the block
+  miner             VARCHAR(65535) NOT NULL,     -- The address of the beneficiary to whom the mining rewards were given
+  difficulty        NUMERIC(38, 0) NOT NULL,     -- Integer of the difficulty for this block
+  total_difficulty  NUMERIC(38, 0) NOT NULL,     -- Integer of the total difficulty of the chain until this block
+  size              BIGINT         NOT NULL,     -- The size of this block in bytes
+  extra_data        VARCHAR(65535) DEFAULT NULL, -- The extra data field of this block
+  gas_limit         BIGINT         DEFAULT NULL, -- The maximum gas allowed in this block
+  gas_used          BIGINT         DEFAULT NULL, -- The total used gas by all transactions in this block
+  transaction_count BIGINT         NOT NULL,
+  base_fee_per_gas  BIGINT         DEFAULT NULL,
+  PRIMARY KEY (chain_id, number)
+)
+DISTKEY (number)
+SORTKEY (chain_id, timestamp);
+
+--
+
+DROP TABLE IF EXISTS ethereum.logs_enrich;
+
+CREATE TABLE ethereum.logs_enrich (
+  chain_id          BIGINT         DEFAULT 1 NOT NULL,     -- Chain ID of network
+  log_index         BIGINT         NOT NULL,     -- Integer of the log index position in the block
+  transaction_hash  VARCHAR(65535) NOT NULL,     -- Hash of the transactions this log was created from
+  transaction_index BIGINT         NOT NULL,     -- Integer of the transactions index position log was created from
+  address           VARCHAR(65535) NOT NULL,     -- Address from which this log originated
+  data              VARCHAR(65535) NOT NULL,     -- Contains one or more 32 Bytes non-indexed arguments of the log
+  topic0            VARCHAR(65535) NOT NULL,     -- Indexed log arguments (0 to 4 32-byte hex strings). (In solidity: The first topic is the hash of the signature of the event (e.g. Deposit(address,bytes32,uint256)), except you declared the event with the anonymous specifier
+  topic1            VARCHAR(65535) NOT NULL,     -- Indexed log arguments (0 to 4 32-byte hex strings)
+  topic2            VARCHAR(65535) NOT NULL,     -- Indexed log arguments (0 to 4 32-byte hex strings)
+  topic3            VARCHAR(65535) NOT NULL,     -- Indexed log arguments (0 to 4 32-byte hex strings)
+  block_number      BIGINT         NOT NULL,     -- The block number where this log was in
+  block_hash        VARCHAR(65535) NOT NULL,     -- Hash of the block where this log was in
+  block_timestamp   TIMESTAMP      NOT NULL,     -- The block timestamp where this log was in
+  PRIMARY KEY (chain_id, transaction_hash, log_index)
+)
+DISTKEY (block_number)
+SORTKEY (chain_id, block_timestamp);
+
+--
+
+DROP TABLE IF EXISTS ethereum.transactions_enrich;
+
+CREATE TABLE ethereum.transactions_enrich (
+  chain_id                    BIGINT         DEFAULT 1 NOT NULL,     -- Chain ID of network
+  hash                        VARCHAR(65535) NOT NULL,     -- Hash of the transaction
+  nonce                       BIGINT         NOT NULL,     -- The number of transactions made by the sender prior to this one
+  transaction_index           BIGINT         NOT NULL,     -- Integer of the transactions index position in the block
+  from_address                VARCHAR(65535) NOT NULL,     -- Address of the sender
+  to_address                  VARCHAR(65535) DEFAULT NULL, -- Address of the receiver. null when its a contract creation transaction
+  value                       NUMERIC(38, 0) NOT NULL,     -- Value transferred in Wei
+  gas                         BIGINT         NOT NULL,     -- Gas provided by the sender
+  gas_price                   BIGINT         NOT NULL,     -- Gas price provided by the sender in Wei
+  input                       VARCHAR(65535) NOT NULL,     -- The data sent along with the transaction
+  block_hash                  VARCHAR(65535) NOT NULL,     -- Hash of the block where this transaction was in
+  block_number                BIGINT         NOT NULL,     -- Block number where this transaction was in
+  block_timestamp             TIMESTAMP      NOT NULL,
+  receipt_cumulative_gas_used BIGINT         NOT NULL,
+  receipt_gas_used            BIGINT         NOT NULL,
+  receipt_contract_address    VARCHAR(65535) DEFAULT NULL,
+  receipt_root                VARCHAR(65535) DEFAULT NULL,
+  receipt_status              BIGINT         DEFAULT NULL,
+  max_fee_per_gas             BIGINT         DEFAULT NULL,
+  max_priority_fee_per_gas    BIGINT         DEFAULT NULL,
+  transaction_type            BIGINT         DEFAULT NULL,
+  receipt_effective_gas_price BIGINT         DEFAULT NULL,
+  PRIMARY KEY (chain_id, hash)
+)
+DISTKEY (block_number)
+SORTKEY (chain_id, block_timestamp);
+
+--
+
+DROP TABLE IF EXISTS ethereum.token_transfers_v2_enrich;
+
+CREATE TABLE ethereum.token_transfers_v2_enrich (
+  chain_id         BIGINT         DEFAULT 1 NOT NULL, -- Chain ID of network
+  from_address     VARCHAR(65535) NOT NULL, -- Address of the sender
+  to_address       VARCHAR(65535) NOT NULL, -- Address of the receiver
+  contract_address VARCHAR(65535) NOT NULL, -- Contract address
+  token_id         VARCHAR(65535) NOT NULL, -- id of the token transferred (ERC721)
+  token_type       VARCHAR(65535) NOT NULL, -- ERC20/ ERC1155/ ERC721
+  amount           VARCHAR(65535) NOT NULL, -- Amount of tokens transferred (ERC20) / id of the token transferred (ERC721). Cast to NUMERIC or FLOAT8
+  transaction_hash VARCHAR(65535) NOT NULL, -- Transaction hash
+  log_index        BIGINT         NOT NULL, -- Log index in the transaction receipt
+  block_number     BIGINT         NOT NULL, -- The block number
+  block_hash       VARCHAR(65535) NOT NULL, -- Hash of the block where this log was in
+  block_timestamp  TIMESTAMP      NOT NULL, -- The block timestamp where this log was in
+  PRIMARY KEY (chain_id, transaction_hash, log_index, token_id)
+)
+DISTKEY (block_number)
+SORTKEY (chain_id, log_index);

--- a/dags/resources/stages/enrich/sqls_redshift/blocks.sql
+++ b/dags/resources/stages/enrich/sqls_redshift/blocks.sql
@@ -1,0 +1,44 @@
+INSERT INTO {{params.schema}}.{{params.table}}
+(
+  chain_id,
+  timestamp,
+  number,
+  hash,
+  parent_hash,
+  nonce,
+  sha3_uncles,
+  logs_bloom,
+  transactions_root,
+  state_root,
+  receipts_root,
+  miner,
+  difficulty,
+  total_difficulty,
+  size,
+  extra_data,
+  gas_limit,
+  gas_used ,
+  transaction_count
+)
+SELECT
+    1 AS chain_id,
+    (TIMESTAMP 'epoch' + timestamp * INTERVAL '1 Second ') AS timestamp,
+    blocks.number,
+    blocks.hash,
+    blocks.parent_hash,
+    blocks.nonce,
+    blocks.sha3_uncles,
+    blocks.logs_bloom,
+    blocks.transactions_root,
+    blocks.state_root,
+    blocks.receipts_root,
+    blocks.miner,
+    blocks.difficulty,
+    blocks.total_difficulty,
+    blocks.size,
+    blocks.extra_data,
+    blocks.gas_limit,
+    blocks.gas_used,
+    blocks.transaction_count
+FROM {{params.schema}}.blocks AS blocks
+where date(TIMESTAMP 'epoch' + timestamp * INTERVAL '1 Second ') = '{{ds}}';

--- a/dags/resources/stages/enrich/sqls_redshift/logs.sql
+++ b/dags/resources/stages/enrich/sqls_redshift/logs.sql
@@ -1,0 +1,33 @@
+INSERT INTO {{params.schema}}.{{params.table}}
+(
+  chain_id,
+  log_index,
+  transaction_hash,
+  transaction_index,
+  address,
+  data,
+  topic0,
+  topic1,
+  topic2,
+  topic3,
+  block_number,
+  block_hash,
+  block_timestamp
+)
+SELECT
+    1 as chain_id,
+    logs.log_index,
+    logs.transaction_hash,
+    logs.transaction_index,
+    logs.address,
+    logs.data,
+    json_extract_array_element_text(topics,0,true) AS topic0,
+    json_extract_array_element_text(topics,1,true) AS topic1,
+    json_extract_array_element_text(topics,2,true) AS topic2,
+    json_extract_array_element_text(topics,3,true) AS topic3,
+    blocks.number AS block_number,
+    blocks.hash AS block_hash,
+    (TIMESTAMP 'epoch' + blocks.timestamp * INTERVAL '1 Second ') AS block_timestamp
+FROM {{params.schema}}.blocks AS blocks
+    JOIN {{params.schema}}.logs AS logs ON blocks.number = logs.block_number
+where date(TIMESTAMP 'epoch' + blocks.timestamp * INTERVAL '1 Second ') = '{{ds}}';

--- a/dags/resources/stages/enrich/sqls_redshift/token_transfers_v2.sql
+++ b/dags/resources/stages/enrich/sqls_redshift/token_transfers_v2.sql
@@ -1,0 +1,31 @@
+INSERT INTO {{params.schema}}.{{params.table}}
+(
+  chain_id,
+  from_address,
+  to_address,
+  contract_address,
+  token_id,
+  token_type,
+  amount,
+  transaction_hash,
+  log_index,
+  block_number,
+  block_hash,
+  block_timestamp
+)
+SELECT
+    1 as chain_id,
+    token_transfers_v2.contract_address,
+    token_transfers_v2.from_address,
+    token_transfers_v2.to_address,
+    token_transfers_v2.amount,
+    token_transfers_v2.token_type,
+    token_transfers_v2.token_ids,
+    token_transfers_v2.transaction_hash,
+    token_transfers_v2.log_index,
+    (TIMESTAMP 'epoch' + blocks.timestamp * INTERVAL '1 Second ') AS block_timestamp,
+    blocks.number AS block_number,
+    blocks.hash AS block_hash
+FROM {{params.schema}}.blocks AS blocks
+    JOIN {{params.schema}}.token_transfers_v2 AS token_transfers_v2 ON blocks.number = token_transfers_v2.block_number
+where date(TIMESTAMP 'epoch' + blocks.timestamp * INTERVAL '1 Second ') = '{{ds}}';

--- a/dags/resources/stages/enrich/sqls_redshift/transactions.sql
+++ b/dags/resources/stages/enrich/sqls_redshift/transactions.sql
@@ -1,0 +1,45 @@
+INSERT INTO {{params.schema}}.{{params.table}}
+(
+  chain_id,
+  hash,
+  nonce,
+  transaction_index,
+  from_address,
+  to_address,
+  value,
+  gas,
+  gas_price,
+  input,
+  receipt_cumulative_gas_used,
+  receipt_gas_used,
+  receipt_contract_address,
+  receipt_root,
+  receipt_status,
+  block_number,
+  block_hash,
+  block_timestamp
+)
+SELECT
+    1 as chain_id,
+    transactions.hash,
+    transactions.nonce,
+    transactions.transaction_index,
+    transactions.from_address,
+    transactions.to_address,
+    transactions.value,
+    transactions.gas,
+    transactions.gas_price,
+    transactions.input,
+    receipts.cumulative_gas_used AS receipt_cumulative_gas_used,
+    receipts.gas_used AS receipt_gas_used,
+    receipts.contract_address AS receipt_contract_address,
+    receipts.root AS receipt_root,
+    receipts.status AS receipt_status,
+    blocks.number AS block_number,
+    blocks.hash AS block_hash,
+    (TIMESTAMP 'epoch' + blocks.timestamp * INTERVAL '1 Second ') AS block_timestamp
+FROM {{params.schema}}.blocks AS blocks
+    JOIN {{params.schema}}.transactions AS transactions ON blocks.number = transactions.block_number
+    JOIN {{params.schema}}.receipts AS receipts ON transactions.hash = receipts.transaction_hash
+where date(TIMESTAMP 'epoch' + blocks.timestamp * INTERVAL '1 Second ') = '{{ds}}';
+


### PR DESCRIPTION
## What is the change?
add enrich tasks to `build_load_dag_redshift`. There are similar enrich tasks in streaming which write to cockroach. batch workflow in `build_load_dag` seems to work only for bigquery and not redshift. So I added support for enrich tasks in `build_load_dag_redshift` to transform data to a similar format in our cockroach tables

Created schema tables in redshift for above tasks

## Why do we need it?
ensures data across streaming and batch are in the same format for backfills and corrections

## Test plan
Tested on airflow

## Todo
use `chain_id` from exports once its available instead of hardcoding the value

## Misc changes
- added `cli.py` to run airflow commands 
- disabled verify_streaming dag 

## Next steps
- backfill enrich tasks from 2021
- Import the s3 files produced into cockroach

